### PR TITLE
Resolve index_order_type requirement in newer versions of Cacti

### DIFF
--- a/Juniper SRX/Screen Statistics/resource/snmp_queries/juniper_srx_screens.xml
+++ b/Juniper SRX/Screen Statistics/resource/snmp_queries/juniper_srx_screens.xml
@@ -1,7 +1,8 @@
 <screen_stats>
-    <name>Juniper SRX Screen Statisticss</name>
+    <name>Juniper SRX Screen Statistics</name>
     <oid_index>.1.3.6.1.4.1.2636.3.39.1.8.1.1.1.1.1</oid_index>
     <index_order>Index</index_order>
+    <index_order_type>alphanumeric</index_order_type>
     <oid_index_parse>OID/REGEXP:^.*\.2636\.3\.39\.1\.8\.1\.1\.1\.1\.[0-9]{1,3}\.(.*)$</oid_index_parse>
     
     <fields>

--- a/Juniper SRX/Security Policy Statistics/resource/snmp_queries/juniper_srx_security_policy.xml
+++ b/Juniper SRX/Security Policy Statistics/resource/snmp_queries/juniper_srx_security_policy.xml
@@ -2,6 +2,7 @@
         <name>Get Juniper SRX Security Policy Stats</name>
         <oid_index>.1.3.6.1.4.1.2636.3.39.1.4.1.1.2.1</oid_index>
         <index_order>Index</index_order>
+        <index_order_type>alphanumeric</index_order_type>
         <oid_index_parse>OID/REGEXP:^.*\.2636\.3\.39\.1\.4\.1\.1\.[0-9]{1,3}\.1\.[0-9]{1,3}\.(.*)$</oid_index_parse>
 
         <fields>


### PR DESCRIPTION
I added `index_order_type` set to `alphanumeric`:

```xml
<index_order>Index</index_order>
<index_order_type>alphanumeric</index_order_type>
```

This was done to both:
juniper_srx_policy.xml
juniper_srx_screens.xml

Additionally, there was a typo in `<name>` that's also been resolved:

From:

```xml
<name>Juniper SRX Screen Statisticss</name>`
```

To:

```xml
<name>Juniper SRX Screen Statistics</name>`
```
